### PR TITLE
Add ValueTypes field consistency checking

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -1852,4 +1852,23 @@ J9NLS_VM_ERROR_TEMPLATE_VALUE_TYPE_SUPERCLASS.sample_input_2=Foo
 J9NLS_VM_ERROR_TEMPLATE_VALUE_TYPE_SUPERCLASS.explanation=Value type classes cannot inherit from classes other than java.lang.Object.
 J9NLS_VM_ERROR_TEMPLATE_VALUE_TYPE_SUPERCLASS.system_action=The JVM will throw a verification or classloading related exception such as java.lang.VerifyError.
 J9NLS_VM_ERROR_TEMPLATE_VALUE_TYPE_SUPERCLASS.user_response=Contact the provider of the classfile for a corrected version.
+
+J9NLS_VM_ERROR_FLATTENABLE_NOT_VALUE_TYPE=bad class %2$.*1$s: flattenable field is not a value type
+# START NON-TRANSLATABLE
+J9NLS_VM_ERROR_FLATTENABLE_NOT_VALUE_TYPE.sample_input_1=3
+J9NLS_VM_ERROR_FLATTENABLE_NOT_VALUE_TYPE.sample_input_2=Foo
+
+J9NLS_VM_ERROR_FLATTENABLE_NOT_VALUE_TYPE.explanation=The class has a field marked flattenable which is not a value type.
+J9NLS_VM_ERROR_FLATTENABLE_NOT_VALUE_TYPE.system_action=The JVM will throw a IncompatibleClassChangeError.
+J9NLS_VM_ERROR_FLATTENABLE_NOT_VALUE_TYPE.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_ERROR_VALUE_TYPE_FIELD_MISSING_ATTRIBUTE=bad class %2$.*1$s: value type field missing from ValueTypes attribute
+# START NON-TRANSLATABLE
+J9NLS_VM_ERROR_VALUE_TYPE_FIELD_MISSING_ATTRIBUTE.sample_input_1=3
+J9NLS_VM_ERROR_VALUE_TYPE_FIELD_MISSING_ATTRIBUTE.sample_input_2=Foo
+
+J9NLS_VM_ERROR_VALUE_TYPE_FIELD_MISSING_ATTRIBUTE.explanation=The class has a value types field which is missing from its ValueType attribute. 
+J9NLS_VM_ERROR_VALUE_TYPE_FIELD_MISSING_ATTRIBUTE.system_action=The JVM will throw a ClassFileError.
+J9NLS_VM_ERROR_VALUE_TYPE_FIELD_MISSING_ATTRIBUTE.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3087,6 +3087,9 @@ typedef struct J9Class {
 #if defined(J9VM_OPT_VALHALLA_NESTMATES)
 	struct J9Class* nestHost;
 #endif /* defined(J9VM_OPT_VALHALLA_NESTMATES) */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	struct J9Class** valueTypeClasses;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 } J9Class;
 
 typedef struct J9ArrayClass {
@@ -3279,6 +3282,9 @@ typedef struct J9ROMClass {
 #define J9ROMCLASS_NESTHOSTNAME(base) SRP_GET((base)->nestHost, struct J9UTF8*)
 #define J9ROMCLASS_NESTMEMBERS(base) SRP_GET((base)->nestMembers, J9SRP*)
 #endif /* J9VM_OPT_VALHALLA_NESTMATES */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#define J9ROMCLASS_VALUETYPECLASSES(base) SRP_GET((base)->valueTypeClasses, J9SRP*)
+#endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 #define J9ROMCLASS_OPTIONALINFO(base) SRP_GET((base)->optionalInfo, U_32*)
 #define J9ROMCLASS_CALLSITEDATA(base) SRP_GET((base)->callSiteData, U_8*)
 #define J9ROMCLASS_STATICSPLITMETHODREFINDEXES(base) SRP_GET((base)->staticSplitMethodRefIndexes, U_16*)

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -59,6 +59,8 @@ static char const *statusNames[] = {
 
 #define STATE_NAME(state) (J9_ARE_ANY_BITS_SET(state, ~(UDATA)J9ClassInitStatusMask) ? "IN_PROGRESS" : statusNames[state])
 
+#define VALUE_TYPE_INSTANCE_FIELD_TAG 1
+
 static j9object_t setInitStatus(J9VMThread *currentThread, J9Class *clazz, UDATA status, j9object_t initializationLock);
 static void classInitStateMachine(J9VMThread *currentThread, J9Class *clazz, J9ClassInitState desiredState);
 
@@ -444,9 +446,48 @@ doVerify:
 					}
 					iTable = iTable->next;
 				}
+				
+				clazz = VM_VMHelpers::currentClass(clazz);
+				
+				/* iterate over fields and load classes of fields marked flattenable and static*/
+				J9SRP *romValueTypeClasses = J9ROMCLASS_VALUETYPECLASSES(clazz->romClass);
+				J9Class **valueTypeClasses = clazz->valueTypeClasses;
+				UDATA valueTypeClassCount = clazz->romClass->valueTypeClassCount;
+				for (UDATA index = 0; (index < valueTypeClassCount) && (NULL != valueTypeClasses[index]); index++) {
+					if (J9_ARE_NO_BITS_SET((uintptr_t) valueTypeClasses[index], VALUE_TYPE_INSTANCE_FIELD_TAG)) {
+						J9UTF8 *signature = (J9UTF8 *) valueTypeClasses[index];
+						J9Class *currentClass = internalFindClassUTF8(currentThread, &J9UTF8_DATA(signature)[1], J9UTF8_LENGTH(signature)-2, clazz->classLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+						if (J9_ARE_NO_BITS_SET(currentClass->romClass->modifiers, J9AccValueType)) {
+							J9UTF8 *badClass = NNSRP_GET(clazz->romClass->className, J9UTF8*);
+							setCurrentExceptionNLSWithArgs(currentThread, J9NLS_VM_ERROR_FLATTENABLE_NOT_VALUE_TYPE, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, J9UTF8_LENGTH(badClass), J9UTF8_DATA(badClass));
+							goto done;
+						}
+
+						J9UTF8 *valueTypeClassName;
+						BOOLEAN found = FALSE;
+						for (UDATA i = 0; i < valueTypeClassCount; i++) {
+							valueTypeClassName = NNSRP_GET(romValueTypeClasses[i], J9UTF8*);
+							if (J9UTF8_EQUALS(signature, valueTypeClassName)) {
+								valueTypeClasses[index] = currentClass;
+								found = TRUE;
+								break;
+							}
+						}
+						if (!found) {
+							J9UTF8 *badClass = NNSRP_GET(clazz->romClass->className, J9UTF8*);
+							setCurrentExceptionNLSWithArgs(currentThread, J9NLS_VM_ERROR_VALUE_TYPE_FIELD_MISSING_ATTRIBUTE, J9VMCONSTANTPOOL_JAVALANGCLASSFORMATERROR, J9UTF8_LENGTH(badClass), J9UTF8_DATA(badClass));
+							goto done;
+						}
+					} else {
+						/* Unset the flagged bit  */
+						valueTypeClasses[index] = (J9Class *)(((uintptr_t) valueTypeClasses[index]) ^ VALUE_TYPE_INSTANCE_FIELD_TAG);
+					}
+				}
+
 				/* Prepare this class */
 				initializationLock = enterInitializationLock(currentThread, initializationLock);
 				clazz = VM_VMHelpers::currentClass(clazz);
+
 				if (NULL == initializationLock) {
 					goto done;
 				}


### PR DESCRIPTION
Add consistency checking between field entries and the valueTypeClasses
ROMClass attribute in loadFlattenableFieldClasses. If a field with the
ACC_FLATTENABLE modifier is not actually a value type (missing
J9AccValueType modifier), throw an ICCE. If the field is not in the
valueTypeClasses attribute, throw a CFE. Otherwise, add a reference to
the field J9Class to its owner's J9Class->valueTypes array.

This change also delays loading static value type fields and adding
them to the valueTypes array until class initialization. A flag on
the least significant bit of the J9Class pointer is used to indicate
that that it is loaded and valid.

Signed-off-by: Mohammad Ali Nikseresht <anikser@ibm.com>